### PR TITLE
Extract `ports` command to own CLI

### DIFF
--- a/bin/mac
+++ b/bin/mac
@@ -19,9 +19,6 @@ Available mac commands:
   empty-trash       Empty trash
   update            Install macOS software updates, Homebrew and installed formulas,
                     Vim and its plugins, Solarized repositories, and dotfiles submodules
-* TCP/IP:
-  free-port         Kill process running on the specified port
-  ports             List all used ports
 
 * WI-FI:
   check-internet    Test network connectivity
@@ -52,17 +49,6 @@ empty_trash() {
 
 launch_screen_saver() {
   open /System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/ScreenSaverEngine.app
-}
-
-#-------------------------------------
-# TCP/IP
-#-------------------------------------
-free_port() {
-  kill "$(lsof -t -i:$2)" 2> /dev/null
-}
-
-list_used_ports() {
-  lsof -iTCP -sTCP:LISTEN -P
 }
 
 #-------------------------------------
@@ -108,12 +94,6 @@ main() {
     info        ) sw_vers ;;
     lock        ) launch_screen_saver ;;
     update      ) update-system ;;
-
-    #-------------------------------------
-    # TCP/IP
-    #-------------------------------------
-    free-port  ) free_port "$@" ;;
-    ports      ) list_used_ports ;;
 
     #-------------------------------------
     # WI-FI

--- a/bin/ports
+++ b/bin/ports
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Manage ports in use.
+
+usage() {
+  cat <<- EOF
+Usage: ports <option> [<args>]
+
+    Manage ports in use.
+
+Available commands:
+    free        Kill process running on the specified port
+    ls          List all ports in use
+EOF
+}
+
+free_port() {
+  kill "$(lsof -t -i:$2)" 2> /dev/null
+}
+
+list_used_ports() {
+  lsof -iTCP -sTCP:LISTEN -P
+}
+
+main() {
+  case $1 in
+    help )
+      usage
+      exit
+      ;;
+
+    free )
+      free_port "$@"
+      ;;
+
+    ls )
+      list_used_ports
+      ;;
+
+    * )
+      echo "ports: '$1' is not a ports command. See 'ports help'."
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/completions/_ports
+++ b/completions/_ports
@@ -1,0 +1,17 @@
+#compdef ports
+
+_ports() {
+  local -a commands
+  commands=(
+    'free:kill process running on the specified port'
+    'ls:list all ports in use'
+  )
+
+  if (( CURRENT == 2 )); then
+    _describe -t commands 'commands' commands
+  fi
+
+  return 0
+}
+
+_ports "$@"

--- a/man/Makefile
+++ b/man/Makefile
@@ -8,6 +8,7 @@ install:
 	install -d -m 755 $(DESTDIR)$(man1dir)
 	pandoc -s -t man git-unpushed.1.md -o man1/git-unpushed.1
 	pandoc -s -t man mac.1.md -o man1/mac.1
+	pandoc -s -t man ports.1.md -o man1/ports.1
 
 print-man1:
 	@for i in $(MAN1_MD); do \

--- a/man/mac.1.md
+++ b/man/mac.1.md
@@ -36,14 +36,6 @@ update
 : Install macOS software updates, Homebrew and installed formulas, Vim and its
 plugins, Solarized repositories, and dotfiles submodules
 
-## TCP/IP
-
-free-port
-: Kill process running on the specified port
-
-ports
-: List all used ports
-
 ## WI-FI
 
 check-internet

--- a/man/ports.1.md
+++ b/man/ports.1.md
@@ -1,0 +1,23 @@
+% ports(1) Version 0.1
+% Rui Afonso Pereira <ruiafonsopereira@gmail.com>
+% 16/Jul/2016
+
+# NAME
+
+ports - Manage ports in use
+
+# SYNOPSIS
+
+*ports* \<option\> [\<args\>]
+
+# DESCRIPTION
+
+Manage ports in use.
+
+# OPTIONS
+
+free
+: Kill process running on the specified port
+
+ls
+: List all ports in use


### PR DESCRIPTION
It makes sense to extract the `ports` command from the `mac` CLI because it is not specific to macOS.
